### PR TITLE
Redirect /spotify to my spotify profile page

### DIFF
--- a/.idea/runConfigurations/dev.xml
+++ b/.idea/runConfigurations/dev.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="dev" type="js.build_tools.npm" nameIsGenerated="true">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="dev" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2">
+      <option name="LaunchBrowser.Before.Run" url="http://localhost:3000" />
+    </method>
+  </configuration>
+</component>

--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,12 @@
 module.exports = {
   reactStrictMode: true,
+  async redirects() {
+    return[
+      {
+        source: '/spotify',
+        destination: 'https://open.spotify.com/user/bernardooliveirajb',
+        permanent: true,
+      },
+    ]
+  },
 };


### PR DESCRIPTION
[✌🌈✌.ml/spotify](https://✌🌈✌.ml/spotify) now redirects to my Spotify™© profile page. i did that using the nextjs config file instead of a custom page file because im a very smart developer and not because that was that was the first result for "nextjs redirect" on google©™

I also added the dev run config with this commit because i did not want to make a separate commit for that

It worked (!)